### PR TITLE
Enable font upload, automatic conversion and subsetting, and listing

### DIFF
--- a/config/nginx-local-media
+++ b/config/nginx-local-media
@@ -8,8 +8,11 @@ server {
 
 	access_log /var/log/nginx/localmedia.good-loop.com/access.log;
 	error_log /var/log/nginx/localmedia.good-loop.com/error.log;
- 
-	
+
+	location ~ \.(ttf|ttc|otf|eot|woff|woff2)$ {
+                add_header Access-Control-Allow-Origin "*";
+        }
+
 	location / {
 		try_files $uri $uri/ @backend;
 	}

--- a/src/java/com/media/FileProcessor.java
+++ b/src/java/com/media/FileProcessor.java
@@ -60,7 +60,7 @@ public class FileProcessor {
 
 
 	/** Assumes that there will already be an image in /uploads/raw for it to find **/
-	public static FileProcessor ImageProcessor(File rawDest, File standardDest, File mobileDest) {
+	public static FileProcessor imageProcessor(File rawDest, File standardDest, File mobileDest) {
 		String inputImagePath = rawDest.getAbsolutePath();
 		String standardImagePath = standardDest.getAbsolutePath();
 		String lowResImagePath = mobileDest.getAbsolutePath();
@@ -99,7 +99,7 @@ public class FileProcessor {
 	}
 
 
-	public static FileProcessor VideoProcessor(File rawDest, File standardDest, File mobileDest, Map params) {
+	public static FileProcessor videoProcessor(File rawDest, File standardDest, File mobileDest, Map params) {
 		String inputVideoPath = rawDest.getAbsolutePath();
 		String lowResVideoPath = mobileDest.getAbsolutePath();
 		String highResVideoPath = standardDest.getAbsolutePath();
@@ -142,9 +142,8 @@ public class FileProcessor {
 	 * @param fontDir Directory to output all generated fonts
 	 * @return
 	 */
-	public static FileProcessor FontProcessor(File rawFont, File fontDir) {
+	public static FileProcessor fontProcessor(File rawFont, File fontDir) {
 		String inputFontPath = rawFont.getAbsolutePath();
-		String baseName = FileUtils.getBasename(rawFont);
 
 		Map<String,File> dests = new HashMap<String, File>();
 
@@ -152,7 +151,7 @@ public class FileProcessor {
 		commands.add("/bin/bash");
 		commands.add("-c");
 		String processSubsetsCommand = "";
-		
+
 		// Generate a non-subsetted, but converted, version of the font
 		File completeWoffDest = new File(fontDir, "all.woff");
 		File completeWoff2Dest = new File(fontDir, "all.woff2");
@@ -161,7 +160,7 @@ public class FileProcessor {
 		processSubsetsCommand += completeConvertCmd.replace("$OUTPUT", completeWoff2Dest.getAbsolutePath());
 		dests.put("all-woff", completeWoffDest);
 		dests.put("all-woff2", completeWoff2Dest);
-		
+
 		// Generate all subsets right now in case we need them later
 		for (String subset : orthographies) {
 			// Subset raw.otf to eg EN.otf, then convert to EN.woff and EN.woff2
@@ -176,7 +175,7 @@ public class FileProcessor {
 
 			// Construct the fontforge command with input = output of subset command
 			String convertCmd = convertCmdBase.replace("$INPUT", subsetDest.getAbsolutePath());
-			
+
 			// Subset, convert to WOFF, convert to WOFF2, delete the unconverted subset.
 			processSubsetsCommand += (
 					subsetCmd

--- a/src/java/com/media/FontServlet.java
+++ b/src/java/com/media/FontServlet.java
@@ -97,10 +97,15 @@ public class FontServlet implements IServlet {
 			KServerType serverType = AppUtils.getServerType(state);
 			String server = AppUtils.getServerUrl(serverType, "media.good-loop.com").toString();
 			String fontName = slugBits[0];
+
+			// Protect against /fonts/../../../../server-home-dir attacks
+			if (!FileUtils.isSafe(fontName)) {
+				throw new WebEx.E400("Given font name contains potentially dangerous components: " + fontName);
+			}
 			
 			File fontDir = new File(fontsRoot, fontName);
 			if (!fontDir.exists()) {
-				throw new WebEx.E400("The requested font \"" + slugBits[0] + "\" does not exist on this server.");
+				throw new WebEx.E400("The requested font \"" + fontName + "\" does not exist on this server.");
 			}
 			File[] list = fontDir.listFiles(); // [EN.woff, EN.woff2, DE.woff, DE.woff2, FR.woff, FR.woff2...]
 			

--- a/src/java/com/media/FontServlet.java
+++ b/src/java/com/media/FontServlet.java
@@ -1,0 +1,134 @@
+package com.media;
+
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.winterwell.utils.FailureException;
+import com.winterwell.utils.Proc;
+import com.winterwell.utils.Utils;
+import com.winterwell.utils.containers.ArrayMap;
+import com.winterwell.utils.io.FileUtils;
+import com.winterwell.utils.log.Log;
+import com.winterwell.utils.time.Time;
+import com.winterwell.utils.web.WebUtils2;
+import com.winterwell.web.FakeBrowser;
+import com.winterwell.web.WebEx;
+import com.winterwell.web.WebInputException;
+import com.winterwell.web.ajax.JSend;
+import com.winterwell.web.ajax.JsonResponse;
+import com.winterwell.web.ajax.KAjaxStatus;
+import com.winterwell.web.app.AppUtils;
+import com.winterwell.web.app.FileServlet;
+import com.winterwell.web.app.IServlet;
+import com.winterwell.web.app.KServerType;
+import com.winterwell.web.app.WebRequest;
+import com.winterwell.web.fields.StringField;
+
+/**
+ * GET /fonts/_list to get a list of uploaded raw fonts & their locations.
+ * GET /fonts/uploaded_font_filename.ttf/_list to get a list of available subsets.
+ * TODO POST /fonts/uploaded_font_filename.ttf/_refresh to reprocess the font for subsets.
+ * Where do fonts go?
+ * 
+ * 
+ * @author roscoe
+ *
+ */
+public class FontServlet implements IServlet {
+	private File webRoot = new File("web/");
+	
+	private File fontsRoot = new File(webRoot, "uploads/fonts/");
+	{
+		if (!fontsRoot.exists()) {
+			boolean ok = fontsRoot.mkdirs();
+			if (!ok) throw new FailureException("Could not create directory " + fontsRoot);
+		}
+	}
+	
+	@Override
+	public void process(WebRequest state) throws IOException {
+		WebUtils2.CORS(state, false);
+		
+		if (!state.isGET()) {
+			throw new WebEx.E40X(405, "This endpoint only supports GET requests");
+		}
+		String[] slugBits = state.getSlugBits();
+		
+		if (slugBits.length > 1) {
+			throw new WebEx.E400("GET /fonts to see all uploaded fonts, or GET /fonts/[font_name] to see available subsets of a font");
+		}
+		
+		// GET media.good-loop.com/fonts = list base font names
+		if (slugBits.length == 0) {
+			File[] list = fontsRoot.listFiles();
+			List<String> fontNames = new ArrayList<String>();
+			for (File subdir : list) {
+				fontNames.add(subdir.getName());
+			}
+			java.util.Collections.sort(fontNames);
+			JSend send = new JSend();
+			send.setStatus(KAjaxStatus.success);
+			send.setData(new ArrayMap("fonts", fontNames));
+			send.send(state);
+			return;
+		} else {
+			// GET media.good-loop.com/fonts/$fontname = list + give URLs for subsets available for $fontname
+			// Get base server URL to construct subset URLs
+			KServerType serverType = AppUtils.getServerType(state);
+			String server = AppUtils.getServerUrl(serverType, "media.good-loop.com").toString();
+			String fontName = slugBits[0];
+			
+			File fontDir = new File(fontsRoot, fontName);
+			if (!fontDir.exists()) {
+				throw new WebEx.E400("The requested font \"" + slugBits[0] + "\" does not exist on this server.");
+			}
+			File[] list = fontDir.listFiles(); // [EN.woff, EN.woff2, DE.woff, DE.woff2, FR.woff, FR.woff2...]
+			
+			
+			// Construct map { "EN": { "woff": "https://url-to-woff", "woff2": "https://url-to-woff2" }, "DE": { "woff": ...etc   
+			Map<String, Object> subsets = new HashMap<String, Object>();
+			for (File subsetFile : list) {
+				String subset = FileUtils.getBasename(subsetFile); // EN, DE, FR...
+				String type = FileUtils.getType(subsetFile); // woff, woff2
+				// https://servername/uploads/fonts/$fontname/$subset.$type
+				String subsetUrl = server + "/uploads/fonts/" + fontName + "/" + subsetFile.getName();
+				
+				// create or get + insert into sub-map
+				Map<String, String> files = (Map<String, String>)subsets.get(subset);
+				if (files == null) {
+					files = new ArrayMap<String, String>(type, subsetUrl);
+					subsets.put(subset, files);
+				} else {
+					files.put(type, subsetUrl);
+				}
+			}
+			JSend send = new JSend();
+			send.setStatus(KAjaxStatus.success);
+			send.setData(new ArrayMap("subsets", subsets));
+			send.send(state);
+			return;
+		}
+		
+		
+	}
+}

--- a/src/java/com/media/MediaMain.java
+++ b/src/java/com/media/MediaMain.java
@@ -44,6 +44,7 @@ public class MediaMain extends AMain<MediaConfig> {
 	@Override
 	protected void addJettyServlets(JettyLauncher jl) {
 		jl.addServlet("/uploads/mediacache/*", new HttpServletWrapper(MediaCacheServlet::new));
+		jl.addServlet("/fonts/*", new HttpServletWrapper(FontServlet::new));
 		jl.addServlet("/*", new HttpServletWrapper(MediaUploadServlet::new));
 		super.addJettyServlets(jl);
 	}

--- a/src/java/com/media/MediaUploadServlet.java
+++ b/src/java/com/media/MediaUploadServlet.java
@@ -224,10 +224,10 @@ public class MediaUploadServlet implements IServlet {
 			Map<String, MediaObject> _assetArr = new ArrayMap();
 
 			if (FileUtils.isImage(tempFile)) {
-				FileProcessor imageProcessor = FileProcessor.ImageProcessor(rawDest, standardDest, mobileDest);
+				FileProcessor imageProcessor = FileProcessor.imageProcessor(rawDest, standardDest, mobileDest);
 				_assetArr = imageProcessor.run(pool);
 			} else if (FileUtils.isVideo(tempFile)) {
-				FileProcessor videoProcessor = FileProcessor.VideoProcessor(rawDest, standardDest, mobileDest, params);
+				FileProcessor videoProcessor = FileProcessor.videoProcessor(rawDest, standardDest, mobileDest, params);
 				_assetArr = videoProcessor.run(pool);
 			} else if (FileUtils.isFont(tempFile)) {
 				// Fonts go in /uploads/fonts/FONT_NAME/
@@ -238,7 +238,7 @@ public class MediaUploadServlet implements IServlet {
 				File rawFontDest = getDestFile(fontDirName, new File("raw." + rawFontExtension));
 				FileUtils.move(rawDest, rawFontDest);
 				// Subsetted versions in same dir named EN.woff, EN.woff2, DE.woff, DE.woff2 etc
-				FileProcessor fontProcessor = FileProcessor.FontProcessor(rawFontDest, baseFontDest);
+				FileProcessor fontProcessor = FileProcessor.fontProcessor(rawFontDest, baseFontDest);
 				_assetArr = fontProcessor.run(pool);
 			}
 			// done

--- a/src/resources/orthographies/ARABIC.txt
+++ b/src/resources/orthographies/ARABIC.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 0600-06FF # 256 character Arabic alphabet range
 2000 #
@@ -112,5 +112,5 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square
 FDFC # Rial symbol

--- a/src/resources/orthographies/CYRILLIC.txt
+++ b/src/resources/orthographies/CYRILLIC.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 0400 # Uppercase cyrillic IE with grave accent
 0401 # Uppercase cyrillic IO
@@ -367,4 +367,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/DE.txt
+++ b/src/resources/orthographies/DE.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 00C4 # Uppercase A with umlaut/diaeresis
 00D6 # Uppercase O with umlaut/diaeresis
@@ -119,4 +119,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/EASTERN_EUROPE.txt
+++ b/src/resources/orthographies/EASTERN_EUROPE.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 00C1 # Uppercase A with acute accent
 00C2 # Uppercase A with circumflex
@@ -234,4 +234,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/EN.txt
+++ b/src/resources/orthographies/EN.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 2000 #
 2001 #
@@ -111,4 +111,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/ES.txt
+++ b/src/resources/orthographies/ES.txt
@@ -89,7 +89,7 @@
 00A1 # inverted exclamation mark
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 00BF # inverted question mark
 00C1 # Uppercase A with acute accent
@@ -127,4 +127,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/FR.txt
+++ b/src/resources/orthographies/FR.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 00C0 # Uppercase A with grave accent
 00C1 # Uppercase A with acute accent
@@ -145,4 +145,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/GR.txt
+++ b/src/resources/orthographies/GR.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 0384 # Greek Tonos
 0385 # Greek Dialytika Tonos
@@ -183,4 +183,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/IT.txt
+++ b/src/resources/orthographies/IT.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 00C0 # Uppercase A with grave accent
 00C8 # Uppercase E with grave accent
@@ -129,4 +129,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/NORDIC.txt
+++ b/src/resources/orthographies/NORDIC.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 00C1 # Uppercase A with acute accent
 00C4 # Uppercase A with umlaut/diaeresis
@@ -137,4 +137,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/PT.txt
+++ b/src/resources/orthographies/PT.txt
@@ -88,7 +88,7 @@
 00A0 #
 00A3 # Pound Sterling Symbol
 00A9 # Copyright Symbol
-00AD # some kind of short minus Symbol
+00AD # Word-break hyphen
 00AE # Registered Symbol
 00C0 # Uppercase A with grave accent
 00C1 # Uppercase A with acute accent
@@ -138,4 +138,4 @@
 205F #
 20AC # Euro Symbol
 2122 # Trademark Symbol
-25FC # a large filled in square symbol
+25FC # Black Medium Square

--- a/src/resources/orthographies/numerals.txt
+++ b/src/resources/orthographies/numerals.txt
@@ -1,0 +1,10 @@
+0030 # Zero
+0031 # One
+0032 # Two
+0033 # Three
+0034 # Four
+0035 # Five
+0036 # Six
+0037 # Seven
+0038 # Eight
+0039 # Nine


### PR DESCRIPTION
Adds a FontProcessor subtype to FileProcessor which generates a set of per-language subsets and converts each to WOFF and WOFF2 for web use. Requires Python fontTools (sudo pip3 install fonttools) and FontForge (sudo apt install fontforge) installed on server to process.
Adds FontServlet, accessible at $serverhost/fonts and $serverhost/fonts/$fontname, which can list available base-fonts and generated subsets for a given font.