### PR TITLE
Remove "setsar=1:1" video filter param which was breaking anamorphic videos

### DIFF
--- a/src/java/com/media/FileProcessor.java
+++ b/src/java/com/media/FileProcessor.java
@@ -120,8 +120,9 @@ public class FileProcessor {
 		// Meaning - start by assuming we'll scale to a 720x720 box, but increase whichever dimension is necessary
 		// to maintain original aspect ratio, and round resultant size to a multiple of 2 to satisfy the encoder.
 		// This allows the same command to handle 4:3, 16:9, portrait, and various non-standard aspect ratios. --RM August 2021
-		String command = "taskset -c 0,1,2,3 ffmpeg -y -i " + inputVideoPath + " -ac 2 -c:a aac -b:a 96k -c:v libx264 -b:v 500k -maxrate 500k -bufsize 1000k -pix_fmt yuv420p -vf colorspace=bt709:iall=bt601-6-625:fast=1,scale=480:480:force_original_aspect_ratio=increase:force_divisible_by=2,setsar=1:1,deblock=filter=strong:block=4 -level:v 3.1 " + lowResVideoPath
-				+ "; taskset -c 0,1,2,3 ffmpeg -y -i " + inputVideoPath + " -ac 2 -c:a aac -b:a 96k -c:v libx264 -b:v 750k -maxrate 750k -bufsize 1500k -pix_fmt yuv420p -vf colorspace=bt709:iall=bt601-6-625:fast=1,scale=720:720:force_original_aspect_ratio=increase:force_divisible_by=2,setsar=1:1,deblock=filter=strong:block=4 -level:v 3.1 " + highResVideoPath;
+		// Removing "setsar=1:1" clause from -vf param list: it was breaking anamorphic videos by discarding pixel-aspect info. --RM July 2023
+		String command = "taskset -c 0,1,2,3 ffmpeg -y -i " + inputVideoPath + " -ac 2 -c:a aac -b:a 96k -c:v libx264 -b:v 500k -maxrate 500k -bufsize 1000k -pix_fmt yuv420p -vf colorspace=bt709:iall=bt601-6-625:fast=1,scale=480:480:force_original_aspect_ratio=increase:force_divisible_by=2,deblock=filter=strong:block=4 -level:v 3.1 " + lowResVideoPath
+				+ "; taskset -c 0,1,2,3 ffmpeg -y -i " + inputVideoPath + " -ac 2 -c:a aac -b:a 96k -c:v libx264 -b:v 750k -maxrate 750k -bufsize 1500k -pix_fmt yuv420p -vf colorspace=bt709:iall=bt601-6-625:fast=1,scale=720:720:force_original_aspect_ratio=increase:force_divisible_by=2,deblock=filter=strong:block=4 -level:v 3.1 " + highResVideoPath;
 		List<String> commands = Arrays.asList("/bin/bash", "-c", command);
 		
 		return new FileProcessor(rawDest, standardDest, mobileDest, commands);


### PR DESCRIPTION
This had no business being in the template command in the first place. Most charitably, we misunderstood that it would resample videos to be correctly sized with square pixels rather than just discard the pixel aspect ratio metadata - or DA copy-pasted it from an ffmpeg recipe on stackoverflow.