### PR TITLE
Bugfix/2023 08/symlink correct path on prod

### DIFF
--- a/src/java/com/media/MediaCacheServlet.java
+++ b/src/java/com/media/MediaCacheServlet.java
@@ -73,6 +73,8 @@ public class MediaCacheServlet implements IServlet {
 	File webRoot = new File("web");
 	
 	private File cacheRoot;
+	
+	private File uploadDir;
 
 	public MediaCacheServlet() {
 		File uploadDir;
@@ -148,7 +150,7 @@ public class MediaCacheServlet implements IServlet {
 					if (srcUrlObj.getHost().equals(reqUrl.getHost()) 
 							&& srcUrlObj.getPath().startsWith("/uploads")) 
 					{
-						File existingFileInDifferentPlace = new File(webRoot, srcUrlObj.getPath());
+						File existingFileInDifferentPlace = new File(uploadDir, srcUrlObj.getPath().replaceFirst("/uploads", ""));
 						try {
 							// If the file is on this uploads server, create a symlink to it in the requested location.
 							// So that next time nginx can handle this

--- a/src/java/com/media/MediaCacheServlet.java
+++ b/src/java/com/media/MediaCacheServlet.java
@@ -74,10 +74,9 @@ public class MediaCacheServlet implements IServlet {
 	
 	private File cacheRoot;
 	
-	private File uploadDir;
+	File uploadDir;
 
 	public MediaCacheServlet() {
-		File uploadDir;
 		MediaConfig mc = Dep.getWithDefault(MediaConfig.class, null);
 		if (mc!= null && mc.uploadDir!=null) {
 			uploadDir = mc.uploadDir;


### PR DESCRIPTION
The bug only triggers when you use MediaCacheServlet to fetch a URL from the same domain that the servlet is running on. So e.g. `media.good-loop.com/uploads/mediacache` trying to cache an image from `media.good-loop.com`.

I have tested this on stage using this URL:

https://stagemedia.good-loop.com/uploads/mediacache/scaled/w/718/aHR0cHM6Ly9zdGFnZW1lZGlhLmdvb2QtbG9vcC5jb20vdXBsb2Fkcy9zdGFuZGFyZC9ydWZmLTg1NzczMDIzNjE1NjUyNTAzODUucG5n.png (tweak the `w` parameter around otherwise you may end up hitting the filesystem once the file has been cached)

The decoded URL is: https://stagemedia.good-loop.com/uploads/standard/ruff-8577302361565250385.png`

It fails on master:

```
Aug 16, 2023 4:26:01 PM Thread[MediaCacheServlet,5,main] SEVERE: MediaCacheServlet #c44c0fcd swallow symlink java.io.FileNotFoundException: web/uploads/standard/ruff-8577302361565250385.png for WebRequest:/scaled/w/718/aHR0cHM6Ly9zdGFnZW1lZGlhLmdvb2QtbG9vcC5jb20vdXBsb2Fkcy9zdGFuZGFyZC9ydWZmLTg1NzczMDIzNjE1NjUyNTAzODUucG5n.png:user=null:action=null:req={}-Browser[linux firefox mobile=false]  stage
```

But works as expected with this tweak. 

Aidan