### PR TITLE
FileProcessor: expand dependency notes for font compression

### DIFF
--- a/src/java/com/media/FileProcessor.java
+++ b/src/java/com/media/FileProcessor.java
@@ -19,8 +19,11 @@ import com.winterwell.utils.log.Log;
  * See {@link MediaCacheServlet} for info on the directory structure this uses
  * and the non-Java dependencies e.g. imagemagick.
  * 
- * Font processing requires Python fontTools and FontForge
- * (sudo pip3 install fonttools, sudo apt install fontforge)
+ * Depends on apt packages:
+ * - fontforge: conversion of fonts
+ * - fonttools: subsetting of fonts with "pyftsubset"
+ * - brotli: enable fontforge to use proper WOFF2 compression
+ * (sudo apt install fontforge fonttools brotli)
  * 
  * TODO @Roscoe - Could you add a unit test for this? Thanks.
  * 


### PR DESCRIPTION
Looks like this was a dependency issue and not a code one in the end - FontForge was quietly using WOFF compression for WOFF2 font files because it didn't have the brotli library available. This commit documents it, actual fix is to install & add to our dependency docs.

Testing notes (to make sure I'm right about this):
- Before installing brotli on the media server, upload a font on `#fonts` on the portal and observe the size of the generated WOFF2 files
- Upload the same font - the generated files should be significantly smaller.